### PR TITLE
Properly align multiple buttons in modal footer

### DIFF
--- a/less/lobes-buttons.less
+++ b/less/lobes-buttons.less
@@ -148,3 +148,8 @@
   border-radius: 2px;
   padding: 6px 12px;
 }
+
+.modal-footer .btn + .btn {
+    margin-left: 5px;
+    margin-bottom: -0.15em;
+}


### PR DESCRIPTION
There was a slight issue with buttons in modals - once an initial button was added in the footer, additional buttons would be slightly vertically offset. This tweak adjusts the height of buttons adjacent to each other to ensure that they are vertically aligned.

The problem here arises from the conflict between:

https://github.com/metabrainz/lobes/blob/master/less/lobes-buttons.less#L7
https://github.com/twbs/bootstrap/blob/master/less/modals.less#L110

Lobes sets a custom margin for its buttons, but this is then overridden by bootstrap for some of the buttons in the modal.
